### PR TITLE
Use Services global variable

### DIFF
--- a/src/implementation.js
+++ b/src/implementation.js
@@ -17,12 +17,11 @@
  */
 
 "use strict";
-/* global ChromeUtils */
+/* global ChromeUtils, Services */
 
 var { ExtensionCommon } = ChromeUtils.import(
   "resource://gre/modules/ExtensionCommon.jsm"
 );
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 // eslint-disable-next-line no-unused-vars
 var tbhints = class extends ExtensionCommon.ExtensionAPI {


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm if the strict_min_version is 91.